### PR TITLE
Fix CVE-2022-23540 (JWT vulnerable to signature validation bypass)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "express-myconnection": "^1.0.4",
     "fs": "^0.0.1-security",
     "https": "^1.0.0",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "mysql2": "^2.3.3",
     "node-fetch": "^3.2.3",


### PR DESCRIPTION
@Yammmma @ZG9K See CVE-2022-23540 

Pretty sure this app could fit the criteria of being vulnerable, just need to update to 9.0.0 or later and it'll be fixed
You might want to check if anything else has changed between 8.5.1 and 9.0.2 that needs to be updated, but I expect not