### PR TITLE
Update mysql to 3.13.0 to silence Dependabot warning

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
     "https": "^1.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
-    "mysql2": "^2.3.3",
+    "mysql2": "^3.13.0",
     "node-fetch": "^3.2.3",
     "path": "^0.12.7",
     "ptv-api": "^0.1.0",


### PR DESCRIPTION
A quick PR which aims to silence the weekly dependabot warnings by setting the mysql2 version in `package.json` to 3.13.0. There are no breaking changes to the server nor the scholext client script.

If not done already, it is recommended mysql2 be updated to version 3.13.0 or later on the prod scholext server to resolve critical vulnerabilities (particularly [this RCE vulnerability](https://github.com/smgs-projects/SchoLExtension/security/dependabot/5)).